### PR TITLE
feat: enlarge 3D viewer and add color swatches for variant selection

### DIFF
--- a/src/components/ModelViewer3D/ModelViewer3D.jsx
+++ b/src/components/ModelViewer3D/ModelViewer3D.jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+
+import styles from "./ModelViewer3D.module.scss";
+
+const ModelViewer3D = ({ model, variants }) => {
+  const [selected, setSelected] = useState("default");
+
+  useEffect(() => {
+    const modelViewer = document.querySelector("model-viewer");
+    if (modelViewer) {
+      modelViewer.variantName = selected === "default" ? null : selected;
+    }
+  }, [selected]);
+
+  return (
+    <div className={styles.viewerWrapper}>
+      <model-viewer
+        src={`/assets/models/${model}`}
+        ar
+        ar-modes="webxr scene-viewer quick-look"
+        camera-controls
+        tone-mapping="neutral"
+        shadow-intensity="1"
+      >
+        <div className="progress-bar hide" slot="progress-bar">
+          <div className="update-bar"></div>
+        </div>
+        <button slot="ar-button" id="ar-button">
+          View in your space
+        </button>
+      </model-viewer>
+
+      {variants.length > 0 && (
+        <div className={styles.variants}>
+          {variants.map(v => (
+            <button
+              key={v.name}
+              className={`${styles.swatch} ${selected === v.name ? styles.active : ""}`}
+              style={{ backgroundColor: v.color }}
+              onClick={() => setSelected(v.name)}
+              title={v.name}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ModelViewer3D;

--- a/src/components/ModelViewer3D/ModelViewer3D.module.scss
+++ b/src/components/ModelViewer3D/ModelViewer3D.module.scss
@@ -1,0 +1,39 @@
+.viewerWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 70vh;
+
+  model-viewer {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+}
+
+.variants {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.swatch {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid #ccc;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+}
+
+.active {
+  border-color: #6145ff;
+  box-shadow: 0 0 0 2px rgba(97, 69, 255, 0.3);
+}

--- a/src/pages/ProductDemoPage/products-list.js
+++ b/src/pages/ProductDemoPage/products-list.js
@@ -1,8 +1,8 @@
 // Action buttons
-const PRODUCT_TYPES = {
-  AR: { id: "ar", label: "See in your environment" },
-  TRY_ON: { id: "ty-on", label: "Live Try On" },
-  CONFIGURE_AI: { id: "configure-ai", label: "Configure in 3D" },
+const ACTION_BUTTONS = {
+  AR: { label: "See in your environment" },
+  TRY_ON: { label: "Live Try On" },
+  CONFIGURE_AI: { label: "Try Outfit with AI" },
 };
 
 // Products
@@ -12,7 +12,7 @@ const glasses = {
   description:
     "Descubre el estilo icónico de los Ray-Ban RB4340 601 Wayfarer, un par de gafas de sol que nunca pasan de moda. Con una montura de color negro hecha de resistente nylon, estos lentes ofrecen una combinación perfecta de durabilidad y elegancia. Las lentes de color verde están fabricadas con vidrio, garantizando una visión clara y una protección óptima contra los rayos solares.",
   price: 16200,
-  type: PRODUCT_TYPES.TRY_ON,
+  action: ACTION_BUTTONS.TRY_ON,
   content: () => import("../MediaPipe3DPage"),
   imgBaseUrl: "/assets/images/glasses-product",
   images: [
@@ -29,14 +29,14 @@ const helmet = {
   description:
     "Descubre el estilo icónico de Helmet, un par de gafas de sol que nunca pasan de moda. Con una montura de color negro hecha de resistente nylon, estos lentes ofrecen una combinación perfecta de durabilidad y elegancia. Las lentes de color verde están fabricadas con vidrio, garantizando una visión clara y una protección óptima contra los rayos solares.",
   price: 31550,
-  type: PRODUCT_TYPES.TRY_ON,
+  action: ACTION_BUTTONS.TRY_ON,
 };
 
 const officeChair = {
   title: "Office chair",
   description: "lorem  ipsum",
   price: 24000,
-  type: PRODUCT_TYPES.AR,
+  action: ACTION_BUTTONS.AR,
   content: () => import("../../components/ModelViewer3D/ModelViewer3D.jsx"),
   contentProps: {
     model: "chair.glb",
@@ -55,7 +55,7 @@ const jacket = {
   title: "Jacket",
   description: "Lorem",
   price: 31550,
-  type: PRODUCT_TYPES.CONFIGURE_AI,
+  action: ACTION_BUTTONS.CONFIGURE_AI,
   content: () => import("../../components/OutfitTryOn/OutfitTryOn.jsx"),
 };
 

--- a/src/pages/ProductDemoPage/products-list.js
+++ b/src/pages/ProductDemoPage/products-list.js
@@ -1,8 +1,8 @@
 // Action buttons
-const ACTION_BUTTONS = {
-  AR: { label: "See in your environment" },
-  TRY_ON: { label: "Live Try On" },
-  CONFIGURE: { label: "Configure in 3D" },
+const PRODUCT_TYPES = {
+  AR: { id: "ar", label: "See in your environment" },
+  TRY_ON: { id: "ty-on", label: "Live Try On" },
+  CONFIGURE_AI: { id: "configure-ai", label: "Configure in 3D" },
 };
 
 // Products
@@ -12,7 +12,7 @@ const glasses = {
   description:
     "Descubre el estilo icónico de los Ray-Ban RB4340 601 Wayfarer, un par de gafas de sol que nunca pasan de moda. Con una montura de color negro hecha de resistente nylon, estos lentes ofrecen una combinación perfecta de durabilidad y elegancia. Las lentes de color verde están fabricadas con vidrio, garantizando una visión clara y una protección óptima contra los rayos solares.",
   price: 16200,
-  action: ACTION_BUTTONS.TRY_ON,
+  type: PRODUCT_TYPES.TRY_ON,
   content: () => import("../MediaPipe3DPage"),
   imgBaseUrl: "/assets/images/glasses-product",
   images: [
@@ -29,15 +29,33 @@ const helmet = {
   description:
     "Descubre el estilo icónico de Helmet, un par de gafas de sol que nunca pasan de moda. Con una montura de color negro hecha de resistente nylon, estos lentes ofrecen una combinación perfecta de durabilidad y elegancia. Las lentes de color verde están fabricadas con vidrio, garantizando una visión clara y una protección óptima contra los rayos solares.",
   price: 31550,
-  action: ACTION_BUTTONS.TRY_ON,
+  type: PRODUCT_TYPES.TRY_ON,
+};
+
+const officeChair = {
+  title: "Office chair",
+  description: "lorem  ipsum",
+  price: 24000,
+  type: PRODUCT_TYPES.AR,
+  content: () => import("../../components/ModelViewer3D/ModelViewer3D.jsx"),
+  contentProps: {
+    model: "chair.glb",
+    variants: [
+      { name: "Default", color: "#000000" },
+      { name: "Variant 2", color: "#341c11" },
+      { name: "Variant 3", color: "#dbdcde" },
+      { name: "Variant 4", color: "#470c0b" },
+      { name: "Variant 5", color: "#2d2d2d" },
+      { name: "Variant 6", color: "#a37845" },
+    ],
+  },
 };
 
 const jacket = {
   title: "Jacket",
   description: "Lorem",
   price: 31550,
-  type: "ai",
-  action: ACTION_BUTTONS.CONFIGURE,
+  type: PRODUCT_TYPES.CONFIGURE_AI,
   content: () => import("../../components/OutfitTryOn/OutfitTryOn.jsx"),
 };
 
@@ -52,6 +70,7 @@ const dummyProduct = {
 export const productList = [
   glasses,
   helmet,
+  officeChair,
   jacket,
   dummyProduct,
   dummyProduct,

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -75,9 +75,9 @@ const ProductPage = () => {
           {/* Product image */}
           <div className="product-image-wrapper">
             {/* Try on button */}
-            {product.type.label && (
+            {product.action.label && (
               <OptionButton
-                label={product.type.label}
+                label={product.action.label}
                 icon={<HiVideoCamera />}
                 isRounded
                 className="try-on-button"

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -75,9 +75,9 @@ const ProductPage = () => {
           {/* Product image */}
           <div className="product-image-wrapper">
             {/* Try on button */}
-            {product.action.label && (
+            {product.type.label && (
               <OptionButton
-                label={product.action.label}
+                label={product.type.label}
                 icon={<HiVideoCamera />}
                 isRounded
                 className="try-on-button"
@@ -134,7 +134,7 @@ const ProductPage = () => {
         <Modal onClose={() => setIsModalOpen(false)} open={isModalOpen}>
           <ErrorBoundary>
             <Suspense fallback={<div>Loading...</div>}>
-              <LazyContent />
+              <LazyContent {...(product.contentProps || {})} />
             </Suspense>
           </ErrorBoundary>
         </Modal>


### PR DESCRIPTION
## Resumen

En esta rama he mejorado la experiencia del visor 3D en modal:

- El componente ModelViewer3D ahora ocupa una mayor altura en la modal (≈70vh) para destacar el modelo en el centro.
- Se ha sustituido el `<select>` de variantes por swatches de color más visuales e intuitivos.
- Las variantes se configuran en product-list.js, permitiendo definir nombre y color por cada producto.

## Cómo probarlo

1. Seleccionar un producto de tipo AR que tenga variantes configuradas en product-list.js.
1. Abrir la modal → el modelo 3D debería mostrarse en grande en el centro.
1. Probar a cambiar de variante haciendo click en los swatches de color → el modelo cambia al color/variante correspondiente.

<img width="1624" height="892" alt="Captura de pantalla 2025-10-02 a las 15 03 46" src="https://github.com/user-attachments/assets/8c735f7d-5437-46f9-b12b-1bfb26387d6e" />